### PR TITLE
Docs return types

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,7 +1,7 @@
 # in this yaml you should add dependencies that are not included in the python packages
 # (or that you want to install anyways such as torch to install cuda w/ conda)
 # also make sure to install the local packages with the "-e" prefix
-# to create an environment: conda create env -f environment.yaml
+# to create an environment: conda env create -f environment.yaml
 # to update: conda env update -f environment.yaml
 name: linen
 channels:

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,23 +5,14 @@
 # to update: conda env update -f environment.yaml
 name: linen
 channels:
-  - pytorch
   - conda-forge
 dependencies:
   - python=3.10
-  - pytorch
-  - cudatoolkit=11.3
-  - torchvision
   - pip
   - pip:
     - numpy
     - matplotlib
     - scipy
-    - wandb
-    - pytorch-lightning
-    - imageio
-    - albumentations
-    - timm
     - pytest
     - pre-commit
     - mypy

--- a/linen/linen/folding/trajectories/circular_fold.py
+++ b/linen/linen/folding/trajectories/circular_fold.py
@@ -31,10 +31,12 @@ def circular_fold_trajectory(
     """
     TODO: make doc.
 
+    For towels, you can use linen.folding.fold_lines.towel.towel_fold_line(keypoints) method.
+
     Args:
         grasp_location: The location of the grasp, i.e. where the gripper closes.
         approach_direction: The approach direction of the gripper.
-        fold_line: Towel center and fold line direction. You can use linen.folding.fold_lines.towel.towel_fold_line(keypoints) method.
+        fold_line: Point on the fold line and fold line direction.
         start_pitch_angle: The pitch angle of the gripper at the start of the fold.
         end_pitch_angle: The pitch angle of the gripper at the end of the fold.
         end_height_offset: The height offset of the gripper at the end of the fold.


### PR DESCRIPTION
conda create env command is wrong, it should be conda env create (maybe verify on your system with `conda create env` vs `conda env create`. I am on conda 23.1.0. 

small docstring change. 

removed unused deps in env.yaml